### PR TITLE
Set environment object if undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,6 +149,10 @@ class InvokeCloudside {
 
     this.serverless.cli.log(`Loading cloudside resources for '${stackName}' stack.`)
 
+    if (!this.serverless.service.provider.environment) {
+      this.serverless.service.provider.environment = {}
+    }
+
     this.serverless.service.provider.environment.IS_CLOUDSIDE = true
     this.serverless.service.provider.environment.CLOUDSIDE_STACK = stackName
 


### PR DESCRIPTION
If I set environment variables on individual functions but didn't have any global environment variables, I'd get an error of `Cannot set property 'IS_CLOUDSIDE' of undefined` on [this line](https://github.com/jeremydaly/serverless-cloudside-plugin/blob/master/index.js#L152) as `this.serverless.service.provider.environment` was undefined.

This just adds a check to see if it's undefined and creates an empty object if not.

Repro `serverless.yml`:

```yml
service: cloudside

provider:
  name: aws
  runtime: nodejs8.10
  stage: dev
  region: us-east-1

functions:
  myFunction:
    handler: handler.handler
    environment:
      QUEUE: !Ref myQueue

resources:
  Resources:
    myQueue:
      Type: AWS::SQS::Queue
      Properties:
        QueueName: ${self:service}-${self:provider.stage}-myQueue

plugins:
  - serverless-cloudside-plugin
```