### PR TITLE
Add Arn support for RDS and SM resource types

### DIFF
--- a/index.js
+++ b/index.js
@@ -272,6 +272,17 @@ const buildCloudValue = (resource,type) => {
   }
 }
 
+const getRdsResourceType = resourceType => {
+  switch(resourceType) {
+    case 'dbcluster':
+      return 'cluster'
+    case 'dbinstance':
+      return 'db'
+    default:
+      return null
+  }
+}
+
 // Generate the ARN based on service type
 // TODO: add more service types or figure out a better way to do this
 const generateArn = resource => {
@@ -288,6 +299,17 @@ const generateArn = resource => {
     case 'dynamodb':
     case 'kinesis':
       stack.push(resourceType[2].toLowerCase()+'/'+resource.PhysicalResourceId)
+      break
+    case 'rds':
+      const rdsResourceType = getRdsResourceType(resourceType[2].toLowerCase())
+      if (!rdsResourceType) {
+        return '<RDS RESOURCE NOT SUPPORTED>'
+      }
+      stack.push(rdsResourceType)
+      stack.push(resource.PhysicalResourceId)
+      break
+    case 'secretsmanager':
+      stack = resource.PhysicalResourceId.split('-').slice(0, -1).join('-').split(':')
       break
     case 's3':
       stack.splice(3,5,'','')


### PR DESCRIPTION
Hey there!
First of all, I wanted to thank you for creating this, it's been great implementing this in our pipeline, made our life for local development quite easier!

This PR is aiming to expand ARN support for more services, specifically RDS and SM (we're using this to simplify access to both RDS and DynamoDB ARN).

There's a fair chance that there are more types specific to RDS that we're not taking into consideration here (only been tested with DB instances and clusters), so it might need further refinement down the read.

Please let me know if you have any feedback! Thanks!