### PR TITLE
feat: Use `catch` instead of `.error` from Bluebird

### DIFF
--- a/index.js
+++ b/index.js
@@ -227,7 +227,7 @@ class InvokeCloudside {
         })
 
         return true
-      }).error(e => {
+      }).catch(e => {
         console.log(e)
       })
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-cloudside-plugin",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Serverless plugin for using cloudside resources during local development",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Due to an ongoing effort to move away from `Bluebird` and use native `async/await` internally in Serverless Framework, some of the functionalities that depend on `Bluebird` API might stop working for users with Framework in version `2.x`. This PR removes the use of `.error` - please let me know if there's a specific functionality of `.error` that was crucial here, but I believe that change should be safe. :crossed_fingers: 