### PR TITLE
feat: Add "serverless" to peerDependecies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
   "homepage": "https://github.com/jeremydaly/serverless-cloudside-plugin#readme",
   "dependencies": {
     "bluebird": "^3.5.4"
+  },
+  "peerDependencies": {
+    "serverless": "1.x || 2.x"
   }
 }


### PR DESCRIPTION
In order to provide more "official" support for potential new major versions of the Serverless Framework, it would be good to define `peerDependencies`, which can later be officially updated to ensure that plugin works with newer versions of the Framework as intended. Please let me know what do you think :bow: 