### PR TITLE
Mark plugin as Serverless Framework v3 ready

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "bluebird": "^3.5.4"
   },
   "peerDependencies": {
-    "serverless": "1.x || 2.x"
+    "serverless": "1 || 2 || 3"
   },
   "files": [
     "index.js"


### PR DESCRIPTION
Plugin is confirmed to work with v3 release without issues, therefore it'll be good to whitelist v3 of the Framework in peer dependencies section