### PR TITLE
Use listStackResources instead of describeStackResources

### DIFF
--- a/index.js
+++ b/index.js
@@ -258,8 +258,7 @@ class InvokeCloudside {
         return true
       }
 
-      this.getStackResources([], { StackName: stackName }, options).then(hander);
-
+      return this.getStackResources([], { StackName: stackName }, options).then(hander);
     } else {
       return BbPromise.resolve()
     }


### PR DESCRIPTION
One of our services contain 178 resources. DescribeStackResources only returns the first 100 results causing the remaining 78 resources to contain the value '<RESOURCE NOT PUBLISHED>'. To resolve this I used listStackResources instead which returns a NextToken used to recursively retrieve the next page of resources from the stack until there are no more resources left. 