### PR TITLE
Enable serverless offline "--reloadHandler" param

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,6 +118,11 @@ class InvokeCloudside {
                 shortcut: 'S',
                 type: 'string',
               },
+              reloadHandler: {
+                usage: 'Enable serverless reload functionality',
+                shortcut: 'r',
+                type: 'boolean',
+              },
               stackName: {
                 usage: 'CloudFormation stack to use for cloudside resources',
                 shortcut: 'y',


### PR DESCRIPTION
Enable serverless offline "--reloadHandler" param. To enable hot-reload when running the server. 

This change enables you to add the --reloadHandler when running the server i.e.

`serverless offline cloudside --reloadHandler`